### PR TITLE
Handling of query_id and loading of inline comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ The projects follows the same API as scikit-learn:
 
 http://scikit-learn.org/dev/datasets/index.html#datasets-in-svmlight-libsvm-format
 
-Unsupported features: multilabel, query_id, reading from file objects.
+Unsupported features: multilabel, reading from file objects.
 
 Public datasets
 ===============

--- a/svmlight_loader.py
+++ b/svmlight_loader.py
@@ -52,7 +52,7 @@ def load_svmlight_file(file_path, n_features=None, dtype=None,
     where X is a scipy.sparse matrix of shape (n_samples, n_features),
           y is a ndarray of shape (n_samples,).
     """
-    data, indices, indptr, labels, comments = _load_svmlight_file(file_path, buffer_mb)
+    data, indices, indptr, labels, comments, qids = _load_svmlight_file(file_path, buffer_mb)
 
     if zero_based is False or \
        (zero_based == "auto" and np.min(indices) > 0):
@@ -68,7 +68,7 @@ def load_svmlight_file(file_path, n_features=None, dtype=None,
 
     X_train = sp.csr_matrix((data, indices, indptr), shape)
 
-    return (X_train, labels, comments)
+    return (X_train, labels, comments, qids)
 
 
 def load_svmlight_files(files, n_features=None, dtype=None, buffer_mb=40):

--- a/svmlight_loader.py
+++ b/svmlight_loader.py
@@ -111,7 +111,7 @@ def load_svmlight_files(files, n_features=None, dtype=None, buffer_mb=40):
     load_svmlight_file
     """
     files = iter(files)
-    result = list(load_svmlight_file(files.next(), n_features, dtype, buffer_mb))
+    result = list(load_svmlight_file(next(files), n_features, dtype, buffer_mb))
     n_features = result[0].shape[1]
 
     for f in files:

--- a/svmlight_loader.py
+++ b/svmlight_loader.py
@@ -52,7 +52,7 @@ def load_svmlight_file(file_path, n_features=None, dtype=None,
     where X is a scipy.sparse matrix of shape (n_samples, n_features),
           y is a ndarray of shape (n_samples,).
     """
-    data, indices, indptr, labels = _load_svmlight_file(file_path, buffer_mb)
+    data, indices, indptr, labels, comments = _load_svmlight_file(file_path, buffer_mb)
 
     if zero_based is False or \
        (zero_based == "auto" and np.min(indices) > 0):
@@ -68,7 +68,7 @@ def load_svmlight_file(file_path, n_features=None, dtype=None,
 
     X_train = sp.csr_matrix((data, indices, indptr), shape)
 
-    return (X_train, labels)
+    return (X_train, labels, comments)
 
 
 def load_svmlight_files(files, n_features=None, dtype=None, buffer_mb=40):
@@ -118,7 +118,7 @@ def load_svmlight_files(files, n_features=None, dtype=None, buffer_mb=40):
     return result
 
 
-def dump_svmlight_file(X, y, f, zero_based=True):
+def dump_svmlight_file(X, y, f, comment, zero_based=True):
     """Dump the dataset in svmlight / libsvm file format.
 
     This format is a text-based format, with one sample per line. It does
@@ -139,6 +139,9 @@ def dump_svmlight_file(X, y, f, zero_based=True):
     f : str
         Specifies the path that will contain the data.
 
+    comment : list, len = n_samples
+        Comments to append to each row after a # character
+
     zero_based : boolean, optional
         Whether column indices should be written zero-based (True) or one-based
         (False).
@@ -150,7 +153,12 @@ def dump_svmlight_file(X, y, f, zero_based=True):
         raise ValueError("X.shape[0] and y.shape[0] should be the same, "
                          "got: %r and %r instead." % (X.shape[0], y.shape[0]))
 
+    if X.shape[0] != len(comment):
+        raise ValueError("X.shape[0] and len(comment) should be the same, "
+                         "got: %r and %r instead." % (X.shape[0], len(comment)))
+
     X = sp.csr_matrix(X, dtype=np.float64)
     y = np.array(y, dtype=np.float64)
+    #comment = np.array(comment, dtype=np.string_)
 
-    _dump_svmlight_file(f, X.data, X.indices, X.indptr, y, int(zero_based))
+    _dump_svmlight_file(f, X.data, X.indices, X.indptr, y, comment, int(zero_based))

--- a/tests/data/svmlight_classification_qid.txt
+++ b/tests/data/svmlight_classification_qid.txt
@@ -1,0 +1,5 @@
+# comment
+1.0 qid:1 2:2.5     10:-5.2 15:1.5 # an inline comment
+2.0 qid:37 5:1.0 12:-3 
+# another comment
+3.0 qid:12 20:27

--- a/tests/test_svmlight_loader.py
+++ b/tests/test_svmlight_loader.py
@@ -12,6 +12,44 @@ currdir = os.path.dirname(os.path.abspath(__file__))
 datafile = os.path.join(currdir, "data", "svmlight_classification.txt")
 invalidfile = os.path.join(currdir, "data", "svmlight_invalid.txt")
 
+qid_datafile         = os.path.join(currdir, "data", "svmlight_classification_qid.txt")
+
+def test_load_svmlight_qid_file():
+    X, y, c, q = load_svmlight_file(qid_datafile)
+
+    # test X's shape
+    assert_equal(X.indptr.shape[0], 4)
+    assert_equal(X.shape[0], 3)
+    assert_equal(X.shape[1], 20)
+    assert_equal(y.shape[0], 3)
+
+    # test X's non-zero values
+    for i, j, val in ((0, 1, 2.5), (0, 9, -5.2), (0, 14, 1.5),
+                     (1, 4, 1.0), (1, 11, -3),
+                     (2, 19, 27)):
+
+        assert_equal(X[i, j], val)
+
+    # tests X's zero values
+    assert_equal(X[0, 2], 0)
+    assert_equal(X[0, 4], 0)
+    assert_equal(X[1, 7], 0)
+    assert_equal(X[1, 15], 0)
+    assert_equal(X[2, 17], 0)
+
+    # test can change X's values
+    X[0, 1] *= 2
+    assert_equal(X[0, 1], 5)
+
+    # test y
+    assert_array_equal(y, [1, 2, 3])
+
+    # test c
+    assert_array_equal(c, [" an inline comment", "", ""])
+
+    # test q
+    assert_array_equal(q, [1, 37, 12])
+
 
 def test_load_svmlight_file():
     X, y, c, q = load_svmlight_file(datafile)
@@ -42,6 +80,12 @@ def test_load_svmlight_file():
 
     # test y
     assert_array_equal(y, [1, 2, 3])
+
+    # test c
+    assert_array_equal(c, [" an inline comment", "", ""])
+
+    # test q
+    assert_equal(q.shape[0], 0)
 
 
 def test_load_svmlight_files():

--- a/tests/test_svmlight_loader.py
+++ b/tests/test_svmlight_loader.py
@@ -149,3 +149,15 @@ def test_dump():
     finally:
         os.remove(tmpfile)
 
+def test_dump_qid():
+    try:
+        Xs, y, c, q = load_svmlight_file(qid_datafile)
+        tmpfile = "tmp_dump.txt"
+        dump_svmlight_file(Xs, y, tmpfile, comment=c, query_id=list(q), zero_based=False)
+        X2, y2, q2 = sk_load_svmlight_file(tmpfile, query_id=True)
+        assert_array_equal(Xs.toarray(), X2.toarray())
+        assert_array_equal(y, y2)
+        assert_array_equal(q, q2)
+    finally:
+        os.remove(tmpfile)
+

--- a/tests/test_svmlight_loader.py
+++ b/tests/test_svmlight_loader.py
@@ -14,7 +14,7 @@ invalidfile = os.path.join(currdir, "data", "svmlight_invalid.txt")
 
 
 def test_load_svmlight_file():
-    X, y = load_svmlight_file(datafile)
+    X, y, c, q = load_svmlight_file(datafile)
 
     # test X's shape
     assert_equal(X.indptr.shape[0], 4)
@@ -45,14 +45,14 @@ def test_load_svmlight_file():
 
 
 def test_load_svmlight_files():
-    X_train, y_train, X_test, y_test = load_svmlight_files([datafile] * 2,
+    X_train, y_train, c_train, q_train, X_test, y_test, c_test, q_test = load_svmlight_files([datafile] * 2,
                                                            dtype=np.float32)
     assert_array_equal(X_train.toarray(), X_test.toarray())
     assert_array_equal(y_train, y_test)
     assert_equal(X_train.dtype, np.float32)
     assert_equal(X_test.dtype, np.float32)
 
-    X1, y1, X2, y2, X3, y3 = load_svmlight_files([datafile] * 3,
+    X1, y1, c1, q1, X2, y2, c2, q2, X3, y3, c3, q3 = load_svmlight_files([datafile] * 3,
                                                  dtype=np.float64)
     assert_equal(X1.dtype, X2.dtype)
     assert_equal(X2.dtype, X3.dtype)
@@ -60,7 +60,7 @@ def test_load_svmlight_files():
 
 
 def test_load_svmlight_file_n_features():
-    X, y = load_svmlight_file(datafile, n_features=14)
+    X, y, c, q = load_svmlight_file(datafile, n_features=14)
 
     # test X'shape
     assert_equal(X.indptr.shape[0], 4)
@@ -96,7 +96,7 @@ def test_invalid_filename():
 
 def test_dump():
     try:
-        Xs, y = load_svmlight_file(datafile)
+        Xs, y, c, q = load_svmlight_file(datafile)
         tmpfile = "tmp_dump.txt"
         dump_svmlight_file(Xs, y, tmpfile, zero_based=False)
         X2, y2 = sk_load_svmlight_file(tmpfile)

--- a/tests/test_svmlight_loader.py
+++ b/tests/test_svmlight_loader.py
@@ -15,7 +15,7 @@ invalidfile = os.path.join(currdir, "data", "svmlight_invalid.txt")
 qid_datafile         = os.path.join(currdir, "data", "svmlight_classification_qid.txt")
 
 def test_load_svmlight_qid_file():
-    X, y, c, q = load_svmlight_file(qid_datafile)
+    X, y, c, q = load_svmlight_file(qid_datafile, comment=True, query_id=True)
 
     # test X's shape
     assert_equal(X.indptr.shape[0], 4)
@@ -51,8 +51,8 @@ def test_load_svmlight_qid_file():
     assert_array_equal(q, [1, 37, 12])
 
 
-def test_load_svmlight_file():
-    X, y, c, q = load_svmlight_file(datafile)
+def test_load_svmlight_file_empty_qid():
+    X, y, c, q = load_svmlight_file(datafile, comment=True, query_id=True)
 
     # test X's shape
     assert_equal(X.indptr.shape[0], 4)
@@ -87,24 +87,68 @@ def test_load_svmlight_file():
     # test q
     assert_equal(q.shape[0], 0)
 
+def test_load_svmlight_file():
+    X, y = load_svmlight_file(datafile)
 
-def test_load_svmlight_files():
+    # test X's shape
+    assert_equal(X.indptr.shape[0], 4)
+    assert_equal(X.shape[0], 3)
+    assert_equal(X.shape[1], 20)
+    assert_equal(y.shape[0], 3)
+
+    # test X's non-zero values
+    for i, j, val in ((0, 1, 2.5), (0, 9, -5.2), (0, 14, 1.5),
+                     (1, 4, 1.0), (1, 11, -3),
+                     (2, 19, 27)):
+
+        assert_equal(X[i, j], val)
+
+    # tests X's zero values
+    assert_equal(X[0, 2], 0)
+    assert_equal(X[0, 4], 0)
+    assert_equal(X[1, 7], 0)
+    assert_equal(X[1, 15], 0)
+    assert_equal(X[2, 17], 0)
+
+    # test can change X's values
+    X[0, 1] *= 2
+    assert_equal(X[0, 1], 5)
+
+    # test y
+    assert_array_equal(y, [1, 2, 3])
+
+def test_load_svmlight_files_comment_qid():
     X_train, y_train, c_train, q_train, X_test, y_test, c_test, q_test = load_svmlight_files([datafile] * 2,
-                                                           dtype=np.float32)
+                                                           dtype=np.float32, comment=True, query_id=True)
     assert_array_equal(X_train.toarray(), X_test.toarray())
     assert_array_equal(y_train, y_test)
     assert_equal(X_train.dtype, np.float32)
     assert_equal(X_test.dtype, np.float32)
 
     X1, y1, c1, q1, X2, y2, c2, q2, X3, y3, c3, q3 = load_svmlight_files([datafile] * 3,
+                                                 dtype=np.float64, comment=True, query_id=True)
+    assert_equal(X1.dtype, X2.dtype)
+    assert_equal(X2.dtype, X3.dtype)
+    assert_equal(X3.dtype, np.float64)
+
+def test_load_svmlight_files():
+    X_train, y_train, X_test, y_test = load_svmlight_files([datafile] * 2,
+                                                           dtype=np.float32)
+    assert_array_equal(X_train.toarray(), X_test.toarray())
+    assert_array_equal(y_train, y_test)
+    assert_equal(X_train.dtype, np.float32)
+    assert_equal(X_test.dtype, np.float32)
+
+    X1, y1, X2, y2, X3, y3 = load_svmlight_files([datafile] * 3,
                                                  dtype=np.float64)
     assert_equal(X1.dtype, X2.dtype)
     assert_equal(X2.dtype, X3.dtype)
     assert_equal(X3.dtype, np.float64)
 
 
+
 def test_load_svmlight_file_n_features():
-    X, y, c, q = load_svmlight_file(datafile, n_features=14)
+    X, y = load_svmlight_file(datafile, n_features=14)
 
     # test X'shape
     assert_equal(X.indptr.shape[0], 4)
@@ -140,7 +184,7 @@ def test_invalid_filename():
 
 def test_dump():
     try:
-        Xs, y, c, q = load_svmlight_file(datafile)
+        Xs, y, = load_svmlight_file(datafile)
         tmpfile = "tmp_dump.txt"
         dump_svmlight_file(Xs, y, tmpfile, zero_based=False)
         X2, y2 = sk_load_svmlight_file(tmpfile)
@@ -151,9 +195,9 @@ def test_dump():
 
 def test_dump_qid():
     try:
-        Xs, y, c, q = load_svmlight_file(qid_datafile)
+        Xs, y, q = load_svmlight_file(qid_datafile, query_id=True)
         tmpfile = "tmp_dump.txt"
-        dump_svmlight_file(Xs, y, tmpfile, comment=c, query_id=list(q), zero_based=False)
+        dump_svmlight_file(Xs, y, tmpfile, query_id=list(q), zero_based=False)
         X2, y2, q2 = sk_load_svmlight_file(tmpfile, query_id=True)
         assert_array_equal(Xs.toarray(), X2.toarray())
         assert_array_equal(y, y2)


### PR DESCRIPTION
1. dump_svmlight_file now has optional arguments for query_id and inline comments
2. load_svmlight_file and load_svmlight_files now have boolean flags to specify whether to load and return inline comments (comment=False and query_id=False by default) 
3.  Tests have also been updated to reflect the changes and they all pass